### PR TITLE
feat: Create Gantt chart for frontend tasks

### DIFF
--- a/frontend/FRONTEND_GANTT.md
+++ b/frontend/FRONTEND_GANTT.md
@@ -1,0 +1,47 @@
+# Frontend Development Gantt Chart
+
+This Gantt chart visualizes the task dependencies and potential timeline for the frontend development tasks outlined in `FRONTEND_BACKLOG.md`.
+
+**Assumptions:**
+*   Each task has a default duration of **1 day**.
+*   The project start date is assumed to be **2024-01-01**.
+*   Tasks are assigned to developers as per the backlog. Tasks under "General/Shared Tasks" are assigned to "All".
+*   The chart shows the earliest possible start time for each task based on its dependencies.
+
+**How to read:**
+*   Each bar represents a task.
+*   Tasks are grouped by the assigned developer.
+*   The timeline at the top indicates dates.
+*   Dependencies are implicitly handled by the start dates of the tasks.
+
+```mermaid
+gantt
+    title Frontend Development Gantt Chart
+    dateFormat  YYYY-MM-DD
+    axisFormat %Y-%m-%d
+
+    section Developer A
+    TASK-FE-001 (A) :TASK-FE-001, 2024-01-01, 1d
+    TASK-FE-002 (A) :TASK-FE-002, 2024-01-02, 1d
+    TASK-FE-003 (A) :TASK-FE-003, 2024-01-03, 1d
+    TASK-FE-004 (A) :TASK-FE-004, 2024-01-03, 1d
+    TASK-FE-005 (A) :TASK-FE-005, 2024-01-04, 1d
+
+    section Developer B
+    TASK-FE-006 (B) :TASK-FE-006, 2024-01-04, 1d
+    TASK-FE-007 (B) :TASK-FE-007, 2024-01-04, 1d
+    TASK-FE-008 (B) :TASK-FE-008, 2024-01-05, 1d
+
+    section Developer C
+    TASK-FE-012 (C) :TASK-FE-012, 2024-01-01, 1d
+    TASK-FE-014 (C) :TASK-FE-014, 2024-01-01, 1d
+    TASK-FE-015 (C) :TASK-FE-015, 2024-01-01, 1d
+    TASK-FE-013 (C) :TASK-FE-013, 2024-01-02, 1d
+    TASK-FE-010 (C) :TASK-FE-010, 2024-01-04, 1d
+    TASK-FE-009 (C) :TASK-FE-009, 2024-01-06, 1d
+    TASK-FE-011 (C) :TASK-FE-011, 2024-01-06, 1d
+
+    section General/Shared Tasks
+    TASK-FE-016 (All) :TASK-FE-016, 2024-01-01, 1d
+    TASK-FE-017 (All) :TASK-FE-017, 2024-01-01, 1d
+```

--- a/gantt_chart.mmd
+++ b/gantt_chart.mmd
@@ -1,0 +1,29 @@
+gantt
+    title Frontend Development Gantt Chart
+    dateFormat  YYYY-MM-DD
+    axisFormat %Y-%m-%d
+
+    section Developer A
+    TASK-FE-001 (A) :TASK-FE-001, 2024-01-01, 1d
+    TASK-FE-002 (A) :TASK-FE-002, 2024-01-02, 1d
+    TASK-FE-003 (A) :TASK-FE-003, 2024-01-03, 1d
+    TASK-FE-004 (A) :TASK-FE-004, 2024-01-03, 1d
+    TASK-FE-005 (A) :TASK-FE-005, 2024-01-04, 1d
+
+    section Developer B
+    TASK-FE-006 (B) :TASK-FE-006, 2024-01-04, 1d
+    TASK-FE-007 (B) :TASK-FE-007, 2024-01-04, 1d
+    TASK-FE-008 (B) :TASK-FE-008, 2024-01-05, 1d
+
+    section Developer C
+    TASK-FE-012 (C) :TASK-FE-012, 2024-01-01, 1d
+    TASK-FE-014 (C) :TASK-FE-014, 2024-01-01, 1d
+    TASK-FE-015 (C) :TASK-FE-015, 2024-01-01, 1d
+    TASK-FE-013 (C) :TASK-FE-013, 2024-01-02, 1d
+    TASK-FE-010 (C) :TASK-FE-010, 2024-01-04, 1d
+    TASK-FE-009 (C) :TASK-FE-009, 2024-01-06, 1d
+    TASK-FE-011 (C) :TASK-FE-011, 2024-01-06, 1d
+
+    section General/Shared Tasks
+    TASK-FE-016 (All) :TASK-FE-016, 2024-01-01, 1d
+    TASK-FE-017 (All) :TASK-FE-017, 2024-01-01, 1d

--- a/generate_gantt.py
+++ b/generate_gantt.py
@@ -1,0 +1,114 @@
+import json
+from datetime import datetime, timedelta
+
+def calculate_gantt_chart_mermaid(tasks_json_path, output_mermaid_path):
+    try:
+        with open(tasks_json_path, 'r') as f:
+            tasks = json.load(f)
+    except FileNotFoundError:
+        print(f"Error: {tasks_json_path} not found.")
+        return
+    except json.JSONDecodeError:
+        print(f"Error: Could not decode JSON from {tasks_json_path}.")
+        return
+
+    task_end_dates = {}
+    task_start_dates = {}
+
+    tasks_by_id = {task['id']: task for task in tasks}
+    task_ids_in_order = [task['id'] for task in tasks] # Keep original order for output if needed
+
+    project_start_date = datetime(2024, 1, 1)
+
+    processed_count_last_iteration = -1
+    while len(task_end_dates) < len(tasks):
+        current_processed_count = len(task_end_dates)
+        for task_id in task_ids_in_order: # Process in original order, but dependencies dictate timing
+            task = tasks_by_id[task_id]
+            if task_id in task_end_dates:
+                continue
+
+            dependencies = task['dependencies']
+            can_process = True
+            calculated_start_date_for_current_task = project_start_date
+
+            if dependencies:
+                dep_end_dates_found = []
+                all_deps_processed = True
+                for dep_id in dependencies:
+                    if dep_id in task_end_dates:
+                        dep_end_dates_found.append(task_end_dates[dep_id])
+                    else:
+                        all_deps_processed = False
+                        break
+
+                if all_deps_processed and dep_end_dates_found:
+                    latest_dependency_finish_date = max(dep_end_dates_found)
+                    calculated_start_date_for_current_task = latest_dependency_finish_date + timedelta(days=1)
+                elif not all_deps_processed:
+                    can_process = False # Skip this task for now
+
+            if can_process:
+                task_start_dates[task_id] = calculated_start_date_for_current_task
+                # A 1-day task finishes on the day it starts.
+                task_end_dates[task_id] = task_start_dates[task_id]
+                # print(f"Processed {task_id}: Starts {task_start_dates[task_id].strftime('%Y-%m-%d')}, Ends {task_end_dates[task_id].strftime('%Y-%m-%d')}")
+
+        if len(task_end_dates) == current_processed_count: # No progress in this iteration
+            print(f"Warning: Stuck. Could not resolve dates for all tasks. Processed: {len(task_end_dates)}/{len(tasks)}")
+            missing_tasks = [t_id for t_id in task_ids_in_order if t_id not in task_end_dates]
+            print(f"Missing tasks: {missing_tasks}")
+            for mt_id in missing_tasks:
+                mt_task = tasks_by_id[mt_id]
+                print(f"  Task {mt_id} dependencies: {mt_task['dependencies']}")
+                for dep_id in mt_task['dependencies']:
+                    if dep_id not in task_end_dates:
+                        print(f"    - Dependency {dep_id} for {mt_id} is also missing/unprocessed.")
+            return # Avoid infinite loop
+
+    dev_tasks_mermaid_entries = {'A': [], 'B': [], 'C': [], 'All': []}
+    # Sort tasks by start date for coherent output within sections
+    sorted_task_ids_by_date = sorted(task_start_dates.keys(), key=lambda tid: task_start_dates[tid])
+
+    for task_id in sorted_task_ids_by_date:
+        task = tasks_by_id[task_id]
+        dev = task['developer']
+
+        mermaid_task_entry = f"    {task_id} ({dev}) :{task_id}, {task_start_dates[task_id].strftime('%Y-%m-%d')}, 1d"
+        if dev in dev_tasks_mermaid_entries:
+            dev_tasks_mermaid_entries[dev].append(mermaid_task_entry)
+        else:
+            dev_tasks_mermaid_entries['All'].append(mermaid_task_entry)
+
+    mermaid_lines = [
+        "gantt",
+        "    title Frontend Development Gantt Chart",
+        "    dateFormat  YYYY-MM-DD",
+        "    axisFormat %Y-%m-%d" # Changed for clarity with YYYY
+    ]
+
+    if dev_tasks_mermaid_entries['A']:
+        mermaid_lines.append("\n    section Developer A")
+        mermaid_lines.extend(dev_tasks_mermaid_entries['A'])
+    if dev_tasks_mermaid_entries['B']:
+        mermaid_lines.append("\n    section Developer B")
+        mermaid_lines.extend(dev_tasks_mermaid_entries['B'])
+    if dev_tasks_mermaid_entries['C']:
+        mermaid_lines.append("\n    section Developer C")
+        mermaid_lines.extend(dev_tasks_mermaid_entries['C'])
+    if dev_tasks_mermaid_entries['All']:
+        mermaid_lines.append("\n    section General/Shared Tasks")
+        mermaid_lines.extend(dev_tasks_mermaid_entries['All'])
+
+    mermaid_output = "\n".join(mermaid_lines)
+
+    try:
+        with open(output_mermaid_path, 'w') as f:
+            # No markdown triple quotes, just pure mermaid syntax as per original thought
+            f.write(mermaid_output)
+        print(f"Mermaid Gantt chart syntax saved to {output_mermaid_path}")
+    except IOError:
+        print(f"Error: Could not write to {output_mermaid_path}.")
+
+if __name__ == "__main__":
+    calculate_gantt_chart_mermaid('parsed_tasks.json', 'gantt_chart.mmd') # Changed extension to .mmd

--- a/parse_backlog.py
+++ b/parse_backlog.py
@@ -1,0 +1,75 @@
+import re
+import json
+
+# Corrected task_pattern:
+# Example: *   **TASK-FE-001 (A):** Initialize Frontend Project
+# Bold text is "**TASK-FE-001 (A):**"
+task_pattern = re.compile(r"^\*\s+\*\*(TASK-FE-\d{3})\s+\(([A-C]|All)\):\*\*\s*(.*)")
+dependency_pattern = re.compile(r"^\s+\*\s+\*\*Depends on:\*\*\s*(.*)")
+task_id_in_dependency_pattern = re.compile(r"TASK-FE-\d{3}")
+
+tasks = []
+current_task_data = {}
+
+backlog_file_path = "frontend/FRONTEND_BACKLOG.md"
+print(f"Attempting to parse {backlog_file_path}")
+
+try:
+    with open(backlog_file_path, "r") as f:
+        for i, line_content in enumerate(f):
+            line = line_content.rstrip("\n")
+            # print(f"Line {i+1}: '{line}'") # Uncomment for full line-by-line debugging
+
+            task_match = task_pattern.match(line)
+
+            if task_match:
+                # print(f"DEBUG: Task matched on line {i+1}: {line}")
+                if current_task_data.get("id"): # If there's data for a previous task, store it
+                    tasks.append(current_task_data)
+
+                task_id = task_match.group(1)
+                developer = task_match.group(2)
+                title = task_match.group(3).strip()
+                current_task_data = {
+                    "id": task_id,
+                    "developer": developer,
+                    "title": title, # Storing title for context, not in final required JSON
+                    "dependencies": []
+                }
+            elif current_task_data.get("id"): # Only look for dependencies if we are "inside" a task
+                dependency_match = dependency_pattern.match(line)
+                if dependency_match:
+                    # print(f"DEBUG: Dependency matched on line {i+1}: {line}")
+                    dependencies_str = dependency_match.group(1)
+                    current_task_data["dependencies"] = task_id_in_dependency_pattern.findall(dependencies_str)
+
+        # After the loop, if current_task_data holds the last processed task, save it.
+        if current_task_data.get("id"):
+            tasks.append(current_task_data)
+
+    # Prepare final list of dictionaries as per requirements (id, developer, dependencies)
+    output_tasks = []
+    for task in tasks:
+        output_tasks.append({
+            "id": task["id"],
+            "developer": task["developer"],
+            "dependencies": task["dependencies"]
+        })
+
+    output_file_path = "parsed_tasks.json"
+    with open(output_file_path, "w") as f:
+        json.dump(output_tasks, f, indent=2)
+
+    print(f"Tasks parsed and saved to {output_file_path}")
+    if not output_tasks:
+        print("Warning: No tasks were extracted. Review patterns and file content.")
+    else:
+        print(f"Successfully extracted {len(output_tasks)} tasks.")
+        # print(json.dumps(output_tasks, indent=2)) # Print JSON to stdout for immediate check
+
+except FileNotFoundError:
+    print(f"Error: File not found at {backlog_file_path}")
+    import os
+    print(f"Current working directory: {os.getcwd()}")
+except Exception as e:
+    print(f"An error occurred: {e}")

--- a/parsed_tasks.json
+++ b/parsed_tasks.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "TASK-FE-001",
+    "developer": "A",
+    "dependencies": []
+  },
+  {
+    "id": "TASK-FE-002",
+    "developer": "A",
+    "dependencies": [
+      "TASK-FE-001"
+    ]
+  },
+  {
+    "id": "TASK-FE-003",
+    "developer": "A",
+    "dependencies": [
+      "TASK-FE-001",
+      "TASK-FE-002"
+    ]
+  },
+  {
+    "id": "TASK-FE-004",
+    "developer": "A",
+    "dependencies": [
+      "TASK-FE-001",
+      "TASK-FE-002"
+    ]
+  },
+  {
+    "id": "TASK-FE-005",
+    "developer": "A",
+    "dependencies": [
+      "TASK-FE-004"
+    ]
+  },
+  {
+    "id": "TASK-FE-006",
+    "developer": "B",
+    "dependencies": [
+      "TASK-FE-001",
+      "TASK-FE-004"
+    ]
+  },
+  {
+    "id": "TASK-FE-007",
+    "developer": "B",
+    "dependencies": [
+      "TASK-FE-001",
+      "TASK-FE-002",
+      "TASK-FE-004"
+    ]
+  },
+  {
+    "id": "TASK-FE-008",
+    "developer": "B",
+    "dependencies": [
+      "TASK-FE-007",
+      "TASK-FE-002"
+    ]
+  },
+  {
+    "id": "TASK-FE-009",
+    "developer": "C",
+    "dependencies": [
+      "TASK-FE-008",
+      "TASK-FE-002",
+      "TASK-FE-013"
+    ]
+  },
+  {
+    "id": "TASK-FE-010",
+    "developer": "C",
+    "dependencies": [
+      "TASK-FE-001",
+      "TASK-FE-002",
+      "TASK-FE-004",
+      "TASK-FE-013"
+    ]
+  },
+  {
+    "id": "TASK-FE-011",
+    "developer": "C",
+    "dependencies": [
+      "TASK-FE-007",
+      "TASK-FE-008",
+      "TASK-FE-013"
+    ]
+  },
+  {
+    "id": "TASK-FE-012",
+    "developer": "C",
+    "dependencies": []
+  },
+  {
+    "id": "TASK-FE-013",
+    "developer": "C",
+    "dependencies": [
+      "TASK-FE-001"
+    ]
+  },
+  {
+    "id": "TASK-FE-014",
+    "developer": "C",
+    "dependencies": []
+  },
+  {
+    "id": "TASK-FE-015",
+    "developer": "C",
+    "dependencies": []
+  },
+  {
+    "id": "TASK-FE-016",
+    "developer": "All",
+    "dependencies": []
+  },
+  {
+    "id": "TASK-FE-017",
+    "developer": "All",
+    "dependencies": []
+  }
+]


### PR DESCRIPTION
This commit introduces a Gantt chart visualizing the frontend development tasks based on the `frontend/FRONTEND_BACKLOG.md` file.

The Gantt chart is provided in Mermaid syntax within the new file `frontend/FRONTEND_GANTT.md`.

Key aspects:
- Tasks are extracted from the backlog, including their assignments and dependencies.
- A default duration of 1 day is assumed for each task for structural visualization.
- The chart illustrates potential parallelism and dependencies between tasks.
- An explanatory note is included in the markdown file regarding assumptions and how to interpret the chart.